### PR TITLE
Change to support ConcurrentMap and AtomicInteger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,8 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>au.org.ala</groupId>
     <artifactId>ala-logger</artifactId>
-    <version>1.3</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ala-logger</name>
     <description>
@@ -94,8 +93,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/org/ala/client/model/LogEventVO.java
+++ b/src/main/java/org/ala/client/model/LogEventVO.java
@@ -16,8 +16,9 @@
 package org.ala.client.model;
 
 import java.io.Serializable;
-import java.util.Hashtable;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
@@ -30,7 +31,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
  */
 
 public class LogEventVO implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private String comment = "";
 
@@ -38,7 +39,7 @@ public class LogEventVO implements Serializable {
 
     private String userIP = "";
     
-    private Map<String, Integer> recordCounts = new Hashtable<String, Integer>();
+    private ConcurrentMap<String, AtomicInteger> recordCounts = new ConcurrentHashMap<>();
 
     private String userEmail = "";
     
@@ -54,19 +55,19 @@ public class LogEventVO implements Serializable {
     public LogEventVO() {
     }
 
-    public LogEventVO(LogEventType eventType, String userEmail, String comment, String userIP, Map<String, Integer> recordCounts) {
+    public LogEventVO(LogEventType eventType, String userEmail, String comment, String userIP, ConcurrentMap<String, AtomicInteger> recordCounts) {
         this(eventType.getId(), null, null, userEmail, comment, userIP, null, recordCounts);
     }
     
-    public LogEventVO(LogEventType eventType, String userEmail, String comment, String userIP, String month, Map<String, Integer> recordCounts) {
+    public LogEventVO(LogEventType eventType, String userEmail, String comment, String userIP, String month, ConcurrentMap<String, AtomicInteger> recordCounts) {
         this(eventType.getId(), null, null, userEmail, comment, userIP, month, recordCounts);
     }
 
-    public LogEventVO(LogEventType eventType, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, Map<String, Integer> recordCounts) {
+    public LogEventVO(LogEventType eventType, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, ConcurrentMap<String, AtomicInteger> recordCounts) {
         this(eventType.getId(), reasonTypeId, sourceTypeId, userEmail, comment, userIP, null, recordCounts);
     }
     
-    public LogEventVO(LogEventType eventType, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, String month, Map<String, Integer> recordCounts) {
+    public LogEventVO(LogEventType eventType, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, String month, ConcurrentMap<String, AtomicInteger> recordCounts) {
         this(eventType.getId(), reasonTypeId, sourceTypeId, userEmail, comment, userIP, month, recordCounts);
     }
     /**
@@ -82,12 +83,12 @@ public class LogEventVO implements Serializable {
      * @param recordCounts
      * @param sourceUrl
      */
-    public LogEventVO(int eventTypeId, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, String month, Map<String, Integer> recordCounts, String sourceUrl) {
+    public LogEventVO(int eventTypeId, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, String month, ConcurrentMap<String, AtomicInteger> recordCounts, String sourceUrl) {
        this(eventTypeId, reasonTypeId, sourceTypeId, userEmail, comment, userIP, month, recordCounts);
        this.sourceUrl = sourceUrl;
     }
     
-    public LogEventVO(int eventTypeId, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, String month, Map<String, Integer> recordCounts) {
+    public LogEventVO(int eventTypeId, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, String month, ConcurrentMap<String, AtomicInteger> recordCounts) {
         this.sourceTypeId = sourceTypeId;
         this.reasonTypeId = reasonTypeId;
         this.eventTypeId = eventTypeId;
@@ -108,7 +109,7 @@ public class LogEventVO implements Serializable {
         }       
     }
 
-    public LogEventVO(int eventTypeId, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, Map<String, Integer> recordCounts) {
+    public LogEventVO(int eventTypeId, Integer reasonTypeId, Integer sourceTypeId, String userEmail, String comment, String userIP, ConcurrentMap<String, AtomicInteger> recordCounts) {
         this(eventTypeId, reasonTypeId, sourceTypeId, userEmail, comment, userIP, null, recordCounts);
     }
     
@@ -128,11 +129,11 @@ public class LogEventVO implements Serializable {
         this.eventTypeId = eventTypeId;
     }
     
-    public Map<String, Integer> getRecordCounts() {
+    public ConcurrentMap<String, AtomicInteger> getRecordCounts() {
         return this.recordCounts;
     }
 
-    public void setRecordCount(Map<String, Integer> recordCounts) {
+    public void setRecordCount(ConcurrentMap<String, AtomicInteger> recordCounts) {
         this.recordCounts = recordCounts;
     }
 

--- a/src/test/java/org/ala/client/LogTest.java
+++ b/src/test/java/org/ala/client/LogTest.java
@@ -6,6 +6,9 @@ import java.util.Calendar;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.ala.client.appender.RestLevel;
 import org.ala.client.appender.RestfulAppender;
@@ -68,11 +71,11 @@ public class LogTest {
 	    	//log to remote ala-logger
 	    	logger.log(RestLevel.REMOTE, sb.toString());
 	    	        	
-	    	Map<String, Integer> recordCounts = new Hashtable<String, Integer>();
+	    	ConcurrentMap<String, AtomicInteger> recordCounts = new ConcurrentHashMap<>();
 	    	// entityUid, record_count
-	    	recordCounts.put("dp123", 32);
-	    	recordCounts.put("dr143", 22);
-	    	recordCounts.put("ins322", 55);
+	    	recordCounts.put("dp123", new AtomicInteger(32));
+	    	recordCounts.put("dr143", new AtomicInteger(22));
+	    	recordCounts.put("ins322", new AtomicInteger(55));
 	    	LogEventVO vo = new LogEventVO(LogEventType.OCCURRENCE_RECORDS_VIEWED, "waiman.mok@csiro.au", "For doing some research with", "127.0.1.1", recordCounts);
 	    	logger.log(RestLevel.REMOTE, vo);
     	}


### PR DESCRIPTION
This change enables the code generating the log statistics to be parallelised much easier, although it requires Java-1.7, so bumping that requirement here

This is related to https://github.com/AtlasOfLivingAustralia/biocache-service/issues/123

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>